### PR TITLE
Add versionHelpers and its use; clean up extra spaces

### DIFF
--- a/src/app/_components/top-app/top-app.component.ts
+++ b/src/app/_components/top-app/top-app.component.ts
@@ -4,6 +4,7 @@ import { interval } from "rxjs/internal/observable/interval";
 import { analyzeAndValidateNgModules } from '@angular/compiler';
 import { Subscribable, Subscription } from 'rxjs';
 import { NgZone } from '@angular/core';
+import { compareSdkPCoreVersions } from 'src/app/_helpers/versionHelpers';
 
 
 @Component({
@@ -35,21 +36,23 @@ export class TopAppComponent implements OnInit {
 
 
   constructor(private cdRef: ChangeDetectorRef,
-              private ngZone: NgZone) { 
+              private ngZone: NgZone) {
 
   }
 
   ngOnInit() {
-    
+
     this.doSubscribe();
   }
-  
+
   doSubscribe() {
 
 
-  
+
     window.PCore.onPCoreReady( (renderObj: any) => {
-    
+      // Check that we're seeing the PCore version we expect
+      compareSdkPCoreVersions();
+
       // Change to reflect new use of arg in the callback:
       const { props /*, domContainerID = null */ } = renderObj;
 
@@ -57,15 +60,15 @@ export class TopAppComponent implements OnInit {
         this.props$ = props;
 
         this.pConn$ = this.props$.getPConnect();
-    
+
         this.sComponentName$ = this.pConn$.getComponentName();
-  
+
         this.store = window.PCore.getStore();
         this.PCore$ = window.PCore;
-  
+
         this.arChildren$ = this.pConn$.getChildren();
-  
-  
+
+
         this.bPCoreReady$ = true;
 
       });

--- a/src/app/_helpers/versionHelpers.ts
+++ b/src/app/_helpers/versionHelpers.ts
@@ -1,0 +1,46 @@
+/**
+ * versionHelpers.ts
+ *
+ * Container helper functions that can identify which version of
+ * PCore/PConnect is being run
+ */
+
+declare const PCore;
+
+export const sdkVersion = "8.6";
+
+export function is86(): boolean {
+  let bRet = false;
+  const theVer = PCore.getPCoreVersion();
+
+  if (theVer.includes("1.0") || theVer.includes("8.6")) {
+    bRet = true;
+  }
+
+  return bRet;
+}
+
+export function is87(): boolean {
+  let bRet = false;
+  const theVer = PCore.getPCoreVersion();
+
+  if (theVer.includes("8.7")) {
+    bRet = true;
+  }
+
+  return bRet;
+}
+
+export function compareSdkPCoreVersions() {
+  if (is86() && sdkVersion.includes("8.6")) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `sdkVersion: ${sdkVersion} matches PCore version: ${PCore.getPCoreVersion()}`
+    );
+  } else {
+    // eslint-disable-next-line no-console
+    console.error(
+      `sdkVersion: ${sdkVersion} does NOT match PCore version: ${PCore.getPCoreVersion()}`
+    );
+  }
+}

--- a/src/app/_samples/full-portal/top-app-mashup/top-app-mashup.component.ts
+++ b/src/app/_samples/full-portal/top-app-mashup/top-app-mashup.component.ts
@@ -12,6 +12,7 @@ import { endpoints } from '../../../_services/endpoints';
 import { UpdateWorklistService } from '../../../_messages/update-worklist.service';
 import { NgZone } from '@angular/core';
 import { ServerConfigService } from '../../../_services/server-config.service';
+import { compareSdkPCoreVersions } from '../../../_helpers/versionHelpers';
 
 
 declare global {
@@ -56,7 +57,7 @@ export class TopAppMashupComponent implements OnInit {
   props$: any;
   PCore$: any;
 
-  
+
 
   storeUnsubscribe : any;
   store: any;
@@ -81,7 +82,7 @@ export class TopAppMashupComponent implements OnInit {
 
 
 
-  constructor(private glsservice: GetLoginStatusService, 
+  constructor(private glsservice: GetLoginStatusService,
     private cdRef: ChangeDetectorRef,
     private snackBar: MatSnackBar,
     private settingsDialog: MatDialog,
@@ -90,17 +91,17 @@ export class TopAppMashupComponent implements OnInit {
     private uwservice: UpdateWorklistService,
     private ngZone: NgZone,
     private scservice: ServerConfigService
-    ) { 
+    ) {
 
 
   }
 
   ngOnInit() {
-    
+
     this.scservice.getServerConfig().then( () => {
       this.initialize();
     });
- 
+
   }
 
   ngOnDestroy() {
@@ -108,7 +109,7 @@ export class TopAppMashupComponent implements OnInit {
     this.progressSpinnerSubscription.unsubscribe();
     this.resetPConnectSubscription.unsubscribe();
   }
-  
+
 
   initialize() {
     if (sessionStorage.getItem("userFullName") && sessionStorage.getItem("userPortal")) {
@@ -129,7 +130,7 @@ export class TopAppMashupComponent implements OnInit {
               this.bLoggedIn$ = true;
               this.userName$ = sessionStorage.getItem("userFullName");
             });
-        
+
             this.getPConnectAndUpdate();
 
           }
@@ -148,7 +149,7 @@ export class TopAppMashupComponent implements OnInit {
             setTimeout(() => {
               window.location.reload();
             })
-           
+
           }
 
 
@@ -157,7 +158,7 @@ export class TopAppMashupComponent implements OnInit {
     );
 
     // handle showing and hiding the progress spinner
-    this.progressSpinnerSubscription = this.psservice.getMessage().subscribe(message => { 
+    this.progressSpinnerSubscription = this.psservice.getMessage().subscribe(message => {
       this.progressSpinnerMessage = message;
 
       this.showHideProgress(this.progressSpinnerMessage.show);
@@ -183,10 +184,10 @@ export class TopAppMashupComponent implements OnInit {
       //     // update the worklist
       //     this.uwservice.sendMessage(true);
 
-          
+
       //   });
 
-       
+
       // }
 
     });
@@ -232,7 +233,7 @@ export class TopAppMashupComponent implements OnInit {
         // OATH
         oHeaders["Authorization"] = sessionStorage.getItem("oauthUser");
       }
-      
+
 
       oConfig["additionalHeaders"] = oHeaders;
 
@@ -259,8 +260,10 @@ export class TopAppMashupComponent implements OnInit {
   pConnectUpdate(oConfig: any, bootstrapShell: any) {
     bootstrapShell.bootstrap(oConfig).then( () => {
 
-        
+
       window.PCore.onPCoreReady( (renderObj) => {
+        // Check that we're seeing the PCore version we expect
+        compareSdkPCoreVersions();
 
 
         // Change to reflect new use of arg in the callback:
@@ -283,24 +286,24 @@ export class TopAppMashupComponent implements OnInit {
 
 
         this.ngZone.run( () => {
-          
+
           this.props$ = props;
-  
+
           this.pConn$ = this.props$.getPConnect();
-      
+
           this.sComponentName$ = this.pConn$.getComponentName();
-    
+
           this.store = window.PCore.getStore();
           this.PCore$ = window.PCore;
-    
+
           this.arChildren$ = this.pConn$.getChildren();
-    
-    
+
+
           this.bPCoreReady$ = true;
 
-  
-  
-        }); 
+
+
+        });
 
 
       } );
@@ -317,15 +320,15 @@ export class TopAppMashupComponent implements OnInit {
     (err) => {
       alert("error");
     }
-    
+
     );
   }
-  
+
 
   showHideProgress(bShow: boolean) {
 
     return;
-    
+
     if (bShow) {
 
       if (!this.isProgress$) {
@@ -361,7 +364,7 @@ export class TopAppMashupComponent implements OnInit {
         });
       }
 
-      
+
     }
   }
 
@@ -374,9 +377,11 @@ export class TopAppMashupComponent implements OnInit {
   doSubscribe() {
 
 
-  
+
     window.PCore.onPCoreReady( (renderObj: any) => {
-    
+      // Check that we're seeing the PCore version we expect
+      compareSdkPCoreVersions();
+
       // Change to reflect new use of arg in the callback:
       const { props /*, domContainerID = null */ } = renderObj;
 
@@ -384,15 +389,15 @@ export class TopAppMashupComponent implements OnInit {
         this.props$ = props;
 
         this.pConn$ = this.props$.getPConnect();
-    
+
         this.sComponentName$ = this.pConn$.getComponentName();
-  
+
         this.store = window.PCore.getStore();
         this.PCore$ = window.PCore;
-  
+
         this.arChildren$ = this.pConn$.getChildren();
-  
-  
+
+
         this.bPCoreReady$ = true;
 
       });
@@ -416,7 +421,7 @@ export class TopAppMashupComponent implements OnInit {
     //     timer.unsubscribe();
 
     //   }
-  
+
     //   });
 
  }

--- a/src/app/_samples/mashup/mc-nav/mc-nav.component.ts
+++ b/src/app/_samples/mashup/mc-nav/mc-nav.component.ts
@@ -16,6 +16,7 @@ import { HttpParams } from '@angular/common/http';
 import { Utils } from "../../../_helpers/utils";
 import { Title } from '@angular/platform-browser';
 import { ServerConfigService } from 'src/app/_services/server-config.service';
+import { compareSdkPCoreVersions } from 'src/app/_helpers/versionHelpers';
 
 
 
@@ -46,7 +47,7 @@ export class MCNavComponent implements OnInit {
 
   bootstrapShell: any;
 
-  constructor(private glsservice: GetLoginStatusService, 
+  constructor(private glsservice: GetLoginStatusService,
               private cdRef: ChangeDetectorRef,
               private snackBar: MatSnackBar,
               private settingsDialog: MatDialog,
@@ -102,8 +103,8 @@ export class MCNavComponent implements OnInit {
           if (!sConfig || sConfig === "") {
             this.dservice.getDataPage("D_OperatorID", operatorParams).subscribe(
               response => {
-  
-              
+
+
                 let operator: any = response.body;
                 //sessionStorage.setItem("loginType", this.loginType$);
                 sessionStorage.setItem("userFullName", operator.pyUserName);
@@ -114,31 +115,31 @@ export class MCNavComponent implements OnInit {
                 this.dservice.getDataPage("D_pxBootstrapConfig", {}).subscribe(
                   response => {
                     this.psservice.sendMessage(false);
-          
+
                     let myConfig : any = response.body;
-        
+
                     sessionStorage.setItem("bootstrapConfig", myConfig.pyConfigJSON);
-      
+
                     //this.glsservice.sendMessage("LoggedIn");
                     this.getPConnectAndUpdate();
-       
-      
-      
+
+
+
                   },
                   err => {
                     this.psservice.sendMessage(false);
-                            
+
                     let sError = "Errors getting config: " + err.message;
                     let snackBarRef = this.snackBar.open(sError, "Ok");
                   }
                 );
-  
-   
-                
+
+
+
               },
               err => {
                 this.psservice.sendMessage(false);
-  
+
                 let sError = "Errors getting data page: " + err.message;
                 let snackBarRef = this.snackBar.open(sError, "Ok");
               }
@@ -146,14 +147,14 @@ export class MCNavComponent implements OnInit {
           }
           else {
             this.psservice.sendMessage(false);
-          
+
             //this.glsservice.sendMessage("LoggedIn");
             this.getPConnectAndUpdate();
           }
 
- 
 
-          
+
+
         }
       },
       err => {
@@ -180,7 +181,7 @@ export class MCNavComponent implements OnInit {
           if (message.loginStatus === 'LoggedIn') {
             this.bLoggedIn$ = true;
             this.userName$ = sessionStorage.getItem("userFullName");
-        
+
             this.getPConnectAndUpdate();
 
           }
@@ -204,7 +205,7 @@ export class MCNavComponent implements OnInit {
     );
 
     // handle showing and hiding the progress spinner
-    this.progressSpinnerSubscription = this.psservice.getMessage().subscribe(message => { 
+    this.progressSpinnerSubscription = this.psservice.getMessage().subscribe(message => {
       this.progressSpinnerMessage = message;
 
       this.showHideProgress(this.progressSpinnerMessage.show);
@@ -228,7 +229,7 @@ export class MCNavComponent implements OnInit {
           timer.unsubscribe();
         });
 
-       
+
       }
 
     });
@@ -258,7 +259,7 @@ export class MCNavComponent implements OnInit {
       }
 
       oConfig["serviceConfig"].staticContentServer = sContentServer;
-      
+
       //oConfig["restServerConfig"] = endpoints.BASEURL.substring(0, endpoints.BASEURL.indexOf("/prweb"));
       oConfig["restServerConfig"] = this.scservice.getBaseUrl().substring(0, this.scservice.getBaseUrl().indexOf("/prweb"));
       oConfig["dynamicLoadComponents"] = false;
@@ -275,7 +276,7 @@ export class MCNavComponent implements OnInit {
         // OATH
         oHeaders["Authorization"] = sessionStorage.getItem("oauthUser");
       }
-      
+
 
       oConfig["additionalHeaders"] = oHeaders;
 
@@ -289,7 +290,7 @@ export class MCNavComponent implements OnInit {
         this.pConnectUpdate(oConfig, bootstrapShell);
       });
 
- 
+
     }
 
   }
@@ -303,9 +304,10 @@ export class MCNavComponent implements OnInit {
       if (!this.PCore$) {
         this.PCore$ = window.PCore;
       }
-      
-      this.PCore$.onPCoreReady( (renderObj) => {
 
+      this.PCore$.onPCoreReady( (renderObj) => {
+      // Check that we're seeing the PCore version we expect
+      compareSdkPCoreVersions();
 
         // Change to reflect new use of arg in the callback:
         const { props /*, domContainerID = null */ } = renderObj;
@@ -329,7 +331,7 @@ export class MCNavComponent implements OnInit {
 
   }
 
-  
+
 
   showHideProgress(bShow: boolean) {
     this.isProgress$ = bShow;
@@ -340,14 +342,7 @@ export class MCNavComponent implements OnInit {
 
   logOff() {
     this.glsservice.sendMessage("LoggedOff");
-    
+
   }
 
 }
-
-
-
-
-
-
-

--- a/src/app/_samples/simple-portal/navigation/navigation.component.ts
+++ b/src/app/_samples/simple-portal/navigation/navigation.component.ts
@@ -12,6 +12,7 @@ import { UpdateWorklistService } from '../../../_messages/update-worklist.servic
 import { NgZone } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ServerConfigService } from 'src/app/_services/server-config.service';
+import { compareSdkPCoreVersions } from 'src/app/_helpers/versionHelpers';
 
 
 
@@ -42,7 +43,7 @@ export class NavigationComponent implements OnInit {
 
 
 
-  constructor(private glsservice: GetLoginStatusService, 
+  constructor(private glsservice: GetLoginStatusService,
               private cdRef: ChangeDetectorRef,
               private snackBar: MatSnackBar,
               private settingsDialog: MatDialog,
@@ -54,7 +55,7 @@ export class NavigationComponent implements OnInit {
 
   ngOnInit() {
 
- 
+
     this.scservice.getServerConfig().then( () => {
       this.initialize();
     });
@@ -105,7 +106,7 @@ export class NavigationComponent implements OnInit {
               this.bLoggedIn$ = true;
               this.userName$ = sessionStorage.getItem("userFullName");
             });
-        
+
             this.getPConnectAndUpdate();
 
           }
@@ -207,7 +208,7 @@ export class NavigationComponent implements OnInit {
         // OATH
         oHeaders["Authorization"] = sessionStorage.getItem("oauthUser");
       }
-      
+
 
       oConfig["additionalHeaders"] = oHeaders;
 
@@ -232,9 +233,10 @@ export class NavigationComponent implements OnInit {
 
     bootstrapShell.bootstrap(oConfig).then(() => {
 
-        
-      window.PCore.onPCoreReady( (renderObj) => {
 
+      window.PCore.onPCoreReady( (renderObj) => {
+        // Check that we're seeing the PCore version we expect
+        compareSdkPCoreVersions();
 
         if (!this.PCore$) {
           this.PCore$ = window.PCore;
@@ -260,12 +262,12 @@ export class NavigationComponent implements OnInit {
           this.PCore$.getConstants().PUB_SUB_EVENTS.EVENT_CANCEL,
           "cancelAssignment"
         );
-    
+
         this.PCore$.getPubSubUtils().unsubscribe(
           "assignmentFinished",
           "assignmentFinished"
         );
-    
+
         this.PCore$.getPubSubUtils().unsubscribe(
           "showWork",
           "showWork"
@@ -280,13 +282,13 @@ export class NavigationComponent implements OnInit {
           () => { this.cancelAssignment() },
           "cancelAssignment"
         );
-    
+
         this.PCore$.getPubSubUtils().subscribe(
           "assignmentFinished",
           () => { this.assignmentFinished() },
           "assignmentFinished"
         );
-    
+
         this.PCore$.getPubSubUtils().subscribe(
           "showWork",
           () => { this.showWork() },
@@ -303,7 +305,7 @@ export class NavigationComponent implements OnInit {
 
     });
   }
-  
+
 
 
 
@@ -311,14 +313,7 @@ export class NavigationComponent implements OnInit {
 
   logOff() {
     this.glsservice.sendMessage("LoggedOff");
-    
+
   }
 
 }
-
-
-
-
-
-
-


### PR DESCRIPTION
New versionHelpers lets us detect and warn of possible SDK/Constellation mismatch.

Also, I'm experimenting with VScode setting and have it set to get rid of extra spaces at EOL