### PR TITLE
8.7 change to where referenceList may appear

### DIFF
--- a/src/app/_components/_templates/simple-table/helpers.ts
+++ b/src/app/_components/_templates/simple-table/helpers.ts
@@ -44,7 +44,9 @@ function getFiledWidth(field, label) {
 export const getContext = (thePConn) => {
   const contextName = thePConn.getContextName();
   const pageReference = thePConn.getPageReference();
-  let { referenceList } = thePConn.getStateProps().config;
+  // 8.7 change = referenceList may now be in top-level of state props, 
+  //  not always in config of state props
+  let { referenceList } = thePConn.getStateProps()?.config || thePConn.getStateProps();
   const pageReferenceForRows = referenceList.startsWith(".")
     ? `${pageReference}.${referenceList.substring(1)}`
     : referenceList;


### PR DESCRIPTION
Constellation 8.7 code shows that referenceList may appear in either getStateProps().config or getStateProps. Handle accordingly.