### PR TITLE
update modal view container if reference children reference resolve a…

### DIFF
--- a/src/app/_components/assignment/assignment.component.ts
+++ b/src/app/_components/assignment/assignment.component.ts
@@ -33,6 +33,8 @@ export class AssignmentComponent implements OnInit {
   workID$: string;
   currentCaseID$: string;
 
+  bIsRefComponent: boolean = false;
+
   templateName$: string;
 
   arMainButtons$: Array<any>;
@@ -90,6 +92,8 @@ export class AssignmentComponent implements OnInit {
     this.angularPConnectData = this.angularPConnect.registerAndSubscribeComponent(this, this.onStateChange);
 
     this.initComponent();
+
+    this.angularPConnect.shouldComponentUpdate( this );
   }
 
   ngOnDestroy() {
@@ -102,6 +106,10 @@ export class AssignmentComponent implements OnInit {
 
   // Callback passed when subscribing to store change
   onStateChange() {
+    this.checkAndUpdate();
+  }
+
+  checkAndUpdate() {
     // Should always check the bridge to see if the component should update itself (re-render)
     const bUpdateSelf = this.angularPConnect.shouldComponentUpdate( this );
 
@@ -120,20 +128,17 @@ export class AssignmentComponent implements OnInit {
 
       }
     }
-
-
-
  }
 
   ngOnChanges() {
-    // debugger;
+
+    this.bIsRefComponent = this.checkIfRefComponent(this.pConn$);
 
     // pConn$ may be a 'reference' component, so normalize it
     this.pConn$ = ReferenceComponent.normalizePConn(this.pConn$);
 
-    // If arChildren$ is null, it means that the pConn$ passed in was a
-    //  'reference' so we need to get the children of the normalized pConn
-    if (!this.arChildren$) {
+    //  If 'reference' so we need to get the children of the normalized pConn
+    if (this.bIsRefComponent) {
       this.arChildren$ = ReferenceComponent.normalizePConnArray(this.pConn$.getChildren());
     }
 
@@ -141,16 +146,24 @@ export class AssignmentComponent implements OnInit {
 
   }
 
+  checkIfRefComponent(thePConn: any):boolean {
+    let bReturn = false;
+    if (thePConn && thePConn.getComponentName() == "reference") {
+      bReturn = true;
+    }
+
+    return bReturn;
+  }
 
   initComponent() {
-    // debugger;
+
+    this.bIsRefComponent = this.checkIfRefComponent(this.pConn$);
 
     // pConn$ may be a 'reference' component, so normalize it
     this.pConn$ = ReferenceComponent.normalizePConn(this.pConn$);
 
-    // If arChildren$ is null, it means that the pConn$ passed in was a
-    //  'reference' so we need to get the children of the normalized pConn
-    if (!this.arChildren$) {
+    // If 'reference' so we need to get the children of the normalized pConn
+    if (this.bIsRefComponent) {
       this.arChildren$ = ReferenceComponent.normalizePConnArray(this.pConn$.getChildren());
     }
 

--- a/src/app/_components/modal-view-container/modal-view-container.component.ts
+++ b/src/app/_components/modal-view-container/modal-view-container.component.ts
@@ -99,6 +99,9 @@ export class ModalViewContainerComponent implements OnInit {
 
     const { CONTAINER_TYPE, PUB_SUB_EVENTS } = this.PCore$.getConstants();
 
+
+    this.angularPConnect.shouldComponentUpdate( this );
+
   }
 
   ngOnChanges(): void {
@@ -144,6 +147,10 @@ export class ModalViewContainerComponent implements OnInit {
 
 
   }
+
+
+
+
 
   // updateSelf
   updateSelf(): void { 


### PR DESCRIPTION
…lways

Check if reference, if so, always resolve children (not if children array blank - this will only happen once because array is global, need to check ever update)