### PR TITLE
Update comment in case we ever revert to old style w/alternate fix

### DIFF
--- a/src/app/_components/reference/reference.component.ts
+++ b/src/app/_components/reference/reference.component.ts
@@ -138,7 +138,7 @@ export class ReferenceComponent implements OnInit {
 
       if (returnObj) {
         //  WAS...
-        // const theRefViewPConn = inPConn.getPConnect().getReferencedViewPConnect();
+        // const theRefViewPConn = inPConn.getPConnect().getReferencedViewPConnect(true);
         // Now: ALWAYS calling createFullReferencedViewFromRef to have options, PageReference, etc.
         //  set correctly in the C11nEnv (PConnect) object
         // debugger;


### PR DESCRIPTION
Latest fix ends up not needing getReferencedViewPConnect(true) but updated commented out code as a reminder in case we ever want to revert to trying to use it.