### PR TITLE
Fix test error for unique match

### DIFF
--- a/tests/e2e/portal.spec.js
+++ b/tests/e2e/portal.spec.js
@@ -171,7 +171,7 @@ test.describe('E2E test', () => {
 
     await page.locator('button:has-text("submit")').click();
 
-    await page.locator('text=Resolved').click();
+    await page.locator('text=RESOLVED-COMPLETED').click();
   }, 10000);
 });
 


### PR DESCRIPTION
Noticed that running the portal test was getting this error:
strict mode violation: "text=Resolved" resolved to 2 elements:
1) <span _ngcontent-nld-c167="" class="psdk-csf-status-st…>Resolved-Completed</span> aka playwright.$("text=Resolved-Completed")
2) <div _ngcontent-nld-c208="" class="psdk-stages-inner-…>…</div> aka playwright.$("app-stages >> text=Resolved")

Made same fix as we had to make in SDK-WC