### PR TITLE
Added extra restrictions for content in an iframe

### DIFF
--- a/src/app/_helpers/auth.js
+++ b/src/app/_helpers/auth.js
@@ -156,6 +156,8 @@ class PegaAuth {
                   // Add Iframe to DOM to have it load
                   document.getElementsByTagName('body')[0].appendChild(elIframe);
                   elIframe.addEventListener("load", myWinOnLoad, true);
+                  // Disallow iframe content attempts to navigate main window
+                  elIframe.setAttribute("sandbox","allow-scripts allow-forms allow-same-origin");
                   elIframe.setAttribute('src', url);
                   const svgCloseBtn =
                   `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
The `sandbox` attribute added to an iframe will add certain restrictions to the content present in the iframe.
Refer [Sandbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox) for more information.