### PR TITLE
Let dev build keep debugger statements; fix live reload

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -105,13 +105,22 @@
                   "maximumError": "5mb"
                 }
               ]
+            },
+            "development": {
+              "optimization": false,
+              "sourceMap": true,
+              "namedChunks": true,
+              "aot": true,
+              "extractLicenses": true,
+              "vendorChunk": true,
+              "buildOptimizer": true
             }
           }
         },
         "serve": {
           "builder": "@angular-builders/custom-webpack:dev-server",
           "options": {
-            "browserTarget": "angularsdk:build",
+            "browserTarget": "angularsdk:build:development",
             "port": 3500
           },
           "configurations": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "_comment": "Commands above are those expected to be run by customers/clients",
     "clean": "node rimraf-standalone.js ./node_modules",
     "ng": "ng",
-    "build": "ng build",
+    "build": "ng build --configuration development",
     "prod-build": "ng build --configuration production",
     "copy-core": "shx cp constellation/constellation-core*.* dist/constellation/prerequisite",
     "compress-angularsdk": "node compress-with-assets.mjs",


### PR DESCRIPTION
It seems that the upgrade to Angular 13 in the main branch ended up defaulting all builds (dev and prod) to be "optimized" (which strips out debugger statements) as well as breaking ng serve's ability to live reload. This PR should fix these issues.