### PR TITLE
8.6 update default to 8.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2768,9 +2768,9 @@
       }
     },
     "@pega/constellationjs": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@pega/constellationjs/-/constellationjs-1.0.8.tgz",
-      "integrity": "sha512-ql6ufVMlIxG8D3spJmktDKXASJ4Lf8vtn167zV5UpFNKwl1v1GtCAtI2WNa4yyLJwyMF7szhD73B58L4GnW5sg=="
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@pega/constellationjs/-/constellationjs-1.0.15.tgz",
+      "integrity": "sha512-aMtsBfwolMUITkPjFer6v6rbg61s80K5yb3inyw2ylRrGh+iAwhc9UcxZsIlYGusMoL1lE64QEa4CoCZdpo0eg=="
     },
     "@schematics/angular": {
       "version": "11.2.14",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@angular/router": "^11.2.14",
     "@mdi/angular-material": "^5.0.45",
     "@mdi/svg": "^5.0.45",
-    "@pega/constellationjs": "SDK-8.6.4",
+    "@pega/constellationjs": "SDK-8.6.5",
     "core-js": "^2.6.12",
     "dayjs": "^1.10.5",
     "downloadjs": "^1.4.7",


### PR DESCRIPTION
With publication of 8.6.5 ConstellationJS files via npm, update the default for release/8.6