### PR TITLE
Update compareSdkPCoreVersions warning message

### DIFF
--- a/src/app/_helpers/versionHelpers.ts
+++ b/src/app/_helpers/versionHelpers.ts
@@ -14,5 +14,5 @@ export function compareSdkPCoreVersions() {
   // const theConstellationVersion = PCore.getPCoreVersion();
 
   // eslint-disable-next-line no-console
-  console.warn(`Using PCore version: ${PCore.getPCoreVersion()}. Confirm this is the same version as your Infinity server.`);
+  console.warn(`Using Constellation version ${PCore.getPCoreVersion()}. Ensure this is the same version as your Infinity server.`);
 }

--- a/src/app/_helpers/versionHelpers.ts
+++ b/src/app/_helpers/versionHelpers.ts
@@ -11,14 +11,8 @@ export const sdkVersion = "8.7";
 
 export function compareSdkPCoreVersions() {
 
-  const theConstellationVersion = PCore.getPCoreVersion();
+  // const theConstellationVersion = PCore.getPCoreVersion();
 
-  if (theConstellationVersion.includes(sdkVersion)) {
-     
-    console.log(`sdkVersion: ${sdkVersion} matches PCore version: ${PCore.getPCoreVersion()}`);
-  } else {
-     
-    console.error(`sdkVersion: ${sdkVersion} does NOT match PCore version: ${PCore.getPCoreVersion()}`);
-  }
-
+  // eslint-disable-next-line no-console
+  console.warn(`Using PCore version: ${PCore.getPCoreVersion()}. Confirm this is the same version as your Infinity server.`);
 }


### PR DESCRIPTION
Updating message to align with changes made earlier to React SDK. Now, a warning since it isn't necessarily an error; just a troubleshooting tip.