### PR TITLE
Bug/spr/bug 767953

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Step 3: Create a Certificate Signing Request (will be prompted for a passphrase 
 
 Step 4: Generate the Certificate
    ```
-   $ openssl x509 -req -days 3650 -in private.csr -signkey private.key -out private.crt -extensions req_ext -extfile ssl.conf
+   $ openssl x509 -req -sha256 -days 3650 -in private.csr -signkey private.key -out private.crt -extensions req_ext -extfile ssl.conf
    ```
 
 Step 5: Add the Certificate to the keychain and trust it (will be prompted for Mac system password)
@@ -338,7 +338,7 @@ Step 5: Add the Certificate to the keychain and trust it (will be prompted for M
 
 Step 6: Create a pem file from crt
    ```
-   $ openssl x509 -in private.crt -out private.pem -outform PEM
+   $ openssl x509 -sha256 -in private.crt -out private.pem -outform PEM
    ```
 Step 7: Run webpack server with arguments to use the keys (assumes private.pem and private.key are in the root project directory).  May need to close prior open instances of browser (if previously accessed prior insecure localhost)
 

--- a/sdk-config.json
+++ b/sdk-config.json
@@ -2,7 +2,7 @@
   "comment_sdk_config": "This is the configuration file for the Angular-SDK",
   "authConfig": {
     "authConfig_comment": "Optional Full paths to Infinity server OAuth endpoints (Only needed if using custom OAuth service)",
-    "authConfig_comment2": "Optional attributes are: authorize, token, revoke, authService, silentTimeout, iframeLoginUI",
+    "authConfig_comment2": "Optional attributes are: authorize, token, revoke, redirectUri, authService, silentTimeout, iframeLoginUI",
     "authService": "pega",
         
     "mashupClient_comment": "Client ID and Client secret from the OAuth 2.0 Client Registration record used for mashup use case",


### PR DESCRIPTION
Support optional argument redirectUri which was added in SDK-R
This allows redirecting to an explicit route that is different than the "current route"
The one caveat is that if loginIfNecessary is called from both these routes, the first argument appName needs to be the same value.  Otherwise, the state from the start of the redirect is lost on the landing to the specified redirect route.