### PR TITLE
Fixed different fonts being used for Case Summary

### DIFF
--- a/src/app/_material_extensions/material-case-summary/material-case-summary.component.scss
+++ b/src/app/_material_extensions/material-case-summary/material-case-summary.component.scss
@@ -86,7 +86,6 @@
     font-size: 0.8125rem;
     font-weight: 400;
     color: rgba(0,0,0,0.8);
-    font-family: "Open Sans";
 }
 
 .psdk-csf-primary-field-data {
@@ -119,7 +118,6 @@
     font-size: 0.8125rem;
     font-weight: 400;
     color: rgba(0,0,0,0.8);
-    font-family: "Open Sans";
 }
 
 .psdk-csf-secondary-field-data {
@@ -132,7 +130,6 @@
 span.psdk-csf-text-style {
     font-size: 1.125rem;
     font-weight: 600;
-    font-family: "Open Sans";
 }
 
 span.psdk-csf-status-style {


### PR DESCRIPTION
* Fixed different fonts being used for Case Summary.
* Please refer BUG-756953 for more details.