### PR TITLE
Properly use SDK Static Content Server for SDK static content

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -6,3 +6,6 @@ The third-party libraries and links to their licenses include the following:
 * Angular - https://angular.io/license
 
 * Angular Material - https://github.com/angular/components/blob/master/LICENSE
+
+Other third-party libraries and links to their licenses can be found in the
+node_modules folder after **npm install** in each project has been run.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4855,6 +4855,11 @@
         }
       }
     },
+    "@pega/constellationjs": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@pega/constellationjs/-/constellationjs-1.0.34.tgz",
+      "integrity": "sha512-6FzoMmLsdVmb6FZaLRo7V4MgXwL6nkHoEo4E0a/jov8CLyw9LvvZ5d6onjLprS5RlgRauYGqs27li9G53RQxhw=="
+    },
     "@pega/cspell-config": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@pega/cspell-config/-/cspell-config-0.3.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "angularsdk",
-  "version": "0.0.0",
+  "name": "angular-sdk",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4854,11 +4854,6 @@
           }
         }
       }
-    },
-    "@pega/constellationjs": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@pega/constellationjs/-/constellationjs-1.0.14.tgz",
-      "integrity": "sha512-YWFcZx2ar2cyMko5hjN7ODEXRqk/WCsXyKNTiFwaaTwlqjEuOP1aApwXxF9rNRG0ar+PzZfa/DL2eOR92KQhuQ=="
     },
     "@pega/cspell-config": {
       "version": "0.3.4",

--- a/src/app/_components/_templates/case-view/case-view.component.ts
+++ b/src/app/_components/_templates/case-view/case-view.component.ts
@@ -130,7 +130,7 @@ export class CaseViewComponent implements OnInit {
     this.arAvailableActions$ = caseInfo?.availableActions ? caseInfo.availableActions : [];
     this.arAvailabeProcesses$ = caseInfo?.availableProcesses ? caseInfo.availableProcesses : [];
 
-    this.svgCase$ = this.utils.getImageSrc(this.configProps$['icon'], this.PCore$.getAssetLoader().getStaticServerUrl());
+    this.svgCase$ = this.utils.getImageSrc(this.configProps$['icon'], this.utils.getSDKStaticContentUrl());
 
     //this.utils.consoleKidDump(this.pConn$);
 

--- a/src/app/_components/_templates/field-group-template/field-group-template.component.ts
+++ b/src/app/_components/_templates/field-group-template/field-group-template.component.ts
@@ -38,7 +38,7 @@ export class FieldGroupTemplateComponent implements OnInit {
 
     let menuIconOverride$ = 'trash';
     if (menuIconOverride$) {
-      this.menuIconOverride$ = this.utils.getImageSrc(menuIconOverride$, this.PCore$.getAssetLoader().getStaticServerUrl());
+      this.menuIconOverride$ = this.utils.getImageSrc(menuIconOverride$, this.utils.getSDKStaticContentUrl());
     }
   }
 

--- a/src/app/_components/_templates/list-view/list-view.component.ts
+++ b/src/app/_components/_templates/list-view/list-view.component.ts
@@ -110,20 +110,20 @@ export class ListViewComponent implements OnInit {
     this.bColumnReorder$ = this.utils.getBooleanValue(this.configProps.reorderFields);
     this.bGrouping$ = this.utils.getBooleanValue(this.configProps.grouping);
 
-    this.menuSvgIcon$ = this.utils.getImageSrc('more', this.PCore$.getAssetLoader().getStaticServerUrl());
-    this.arrowDownSvgIcon$ = this.utils.getImageSrc('arrow-down', this.PCore$.getAssetLoader().getStaticServerUrl());
-    this.arrowUpSvgIcon$ = this.utils.getImageSrc('arrow-up', this.PCore$.getAssetLoader().getStaticServerUrl());
+    this.menuSvgIcon$ = this.utils.getImageSrc('more', this.utils.getSDKStaticContentUrl());
+    this.arrowDownSvgIcon$ = this.utils.getImageSrc('arrow-down', this.utils.getSDKStaticContentUrl());
+    this.arrowUpSvgIcon$ = this.utils.getImageSrc('arrow-up', this.utils.getSDKStaticContentUrl());
 
-    this.filterSvgIcon$ = this.utils.getImageSrc('filter', this.PCore$.getAssetLoader().getStaticServerUrl());
-    this.filterOnSvgIcon$ = this.utils.getImageSrc('filter-on', this.PCore$.getAssetLoader().getStaticServerUrl());
-    this.groupBySvgIcon$ = this.utils.getImageSrc('row', this.PCore$.getAssetLoader().getStaticServerUrl());
+    this.filterSvgIcon$ = this.utils.getImageSrc('filter', this.utils.getSDKStaticContentUrl());
+    this.filterOnSvgIcon$ = this.utils.getImageSrc('filter-on', this.utils.getSDKStaticContentUrl());
+    this.groupBySvgIcon$ = this.utils.getImageSrc('row', this.utils.getSDKStaticContentUrl());
 
     this.selectionMode = this.configProps.selectionMode;
 
     this.arFilterMainButtons$.push({ actionID: 'submit', jsAction: 'submit', name: 'Submit' });
     this.arFilterSecondaryButtons$.push({ actionID: 'cancel', jsAction: 'cancel', name: 'Cancel' });
 
-    this.searchIcon$ = this.utils.getImageSrc('search', this.PCore$.getAssetLoader().getStaticServerUrl());
+    this.searchIcon$ = this.utils.getImageSrc('search', this.utils.getSDKStaticContentUrl());
     this.getListData();
   }
 

--- a/src/app/_components/_templates/simple-table-manual/simple-table-manual.component.ts
+++ b/src/app/_components/_templates/simple-table-manual/simple-table-manual.component.ts
@@ -52,7 +52,7 @@ export class SimpleTableManualComponent implements OnInit {
       this.PCore$ = window.PCore;
     }
     // Then, continue on with other initialization
-    this.menuIconOverride$ = this.utils.getImageSrc('trash', this.PCore$.getAssetLoader().getStaticServerUrl());
+    this.menuIconOverride$ = this.utils.getImageSrc('trash', this.utils.getSDKStaticContentUrl());
     // call checkAndUpdate when initializing
     this.checkAndUpdate();
   }

--- a/src/app/_components/_widgets/file-utility/file-utility.component.ts
+++ b/src/app/_components/_widgets/file-utility/file-utility.component.ts
@@ -81,7 +81,7 @@ export class FileUtilityComponent implements OnInit {
     this.lu_name$ = configProps.label;
     this.lu_icon$ = 'paper-clip';
 
-    this.closeSvgIcon$ = this.utils.getImageSrc('times', this.PCore$.getAssetLoader().getStaticServerUrl());
+    this.closeSvgIcon$ = this.utils.getImageSrc('times', this.utils.getSDKStaticContentUrl());
 
     let onViewAllCallback = () => this.onViewAll(this.arFullListAttachments);
 

--- a/src/app/_components/_widgets/list-utility/list-utility.component.ts
+++ b/src/app/_components/_widgets/list-utility/list-utility.component.ts
@@ -35,13 +35,13 @@ export class ListUtilityComponent implements OnInit {
 
     this.imagePath$ = this.getIconPath();
 
-    this.headerSvgIcon$ = this.utils.getImageSrc(this.icon$, this.PCore$.getAssetLoader().getStaticServerUrl());
-    this.settingsSvgIcon$ = this.utils.getImageSrc('more', this.PCore$.getAssetLoader().getStaticServerUrl());
+    this.headerSvgIcon$ = this.utils.getImageSrc(this.icon$, this.utils.getSDKStaticContentUrl());
+    this.settingsSvgIcon$ = this.utils.getImageSrc('more', this.utils.getSDKStaticContentUrl());
   }
 
   ngOnChanges() {}
 
   getIconPath(): string {
-    return this.PCore$.getAssetLoader().getStaticServerUrl() + 'assets/icons/';
+    return this.utils.getSDKStaticContentUrl() + 'assets/icons/';
   }
 }

--- a/src/app/_components/feed-container/feed-container.component.ts
+++ b/src/app/_components/feed-container/feed-container.component.ts
@@ -351,10 +351,10 @@ export class FeedContainerComponent implements OnInit {
     */
 
     // set up svg images
-    this.svgComment$ = this.utils.getImageSrc('chat', this.PCore$.getAssetLoader().getStaticServerUrl());
-    this.svgLike$ = this.utils.getImageSrc('thumbs-up', this.PCore$.getAssetLoader().getStaticServerUrl());
-    this.svgLikedByMe$ = this.utils.getImageSrc('thumbs-up-solid', this.PCore$.getAssetLoader().getStaticServerUrl());
-    this.svgSend$ = this.utils.getImageSrc('send', this.PCore$.getAssetLoader().getStaticServerUrl());
+    this.svgComment$ = this.utils.getImageSrc('chat', this.utils.getSDKStaticContentUrl());
+    this.svgLike$ = this.utils.getImageSrc('thumbs-up', this.utils.getSDKStaticContentUrl());
+    this.svgLikedByMe$ = this.utils.getImageSrc('thumbs-up-solid', this.utils.getSDKStaticContentUrl());
+    this.svgSend$ = this.utils.getImageSrc('send', this.utils.getSDKStaticContentUrl());
   }
 
   ngOnDestroy(): void {

--- a/src/app/_components/flow-container/flow-container.component.ts
+++ b/src/app/_components/flow-container/flow-container.component.ts
@@ -417,7 +417,7 @@ export class FlowContainerComponent implements OnInit {
     this.caseMessages$ = this.pConn$.getValue('caseMessages');
     if (this.caseMessages$ || !this.hasAssignments()) {
       this.bHasCaseMessages$ = true;
-      this.checkSvg$ = this.utils.getImageSrc('check', this.PCore$.getAssetLoader().getStaticServerUrl());
+      this.checkSvg$ = this.utils.getImageSrc('check', this.utils.getSDKStaticContentUrl());
       // Temp fix for 8.7 change: confirmationNote no longer coming through in caseMessages$.
       // So, if we get here and caseMessages$ is empty, use default value in DX API response
       if (!this.caseMessages$) {

--- a/src/app/_components/multi-step/multi-step.component.ts
+++ b/src/app/_components/multi-step/multi-step.component.ts
@@ -33,8 +33,8 @@ export class MultiStepComponent implements OnInit {
     }
 
     // svg icons
-    this.svgCurrent$ = this.utils.getImageSrc('circle-solid', this.PCore$.getAssetLoader().getStaticServerUrl());
-    this.svgNotCurrent$ = this.utils.getImageSrc('circle-solid', this.PCore$.getAssetLoader().getStaticServerUrl());
+    this.svgCurrent$ = this.utils.getImageSrc('circle-solid', this.utils.getSDKStaticContentUrl());
+    this.svgNotCurrent$ = this.utils.getImageSrc('circle-solid', this.utils.getSDKStaticContentUrl());
   }
 
   onActionButtonClick(oData: any) {

--- a/src/app/_components/navbar/navbar.component.ts
+++ b/src/app/_components/navbar/navbar.component.ts
@@ -57,7 +57,7 @@ export class NavbarComponent implements OnInit {
     // First thing in initialization is registering and subscribing to the AngularPConnect service
     this.angularPConnectData = this.angularPConnect.registerAndSubscribeComponent(this, this.onStateChange);
 
-    this.navIcon$ = this.PCore$.getAssetLoader().getStaticServerUrl().concat('assets/pzpega-logo-mark.svg');
+    this.navIcon$ = this.utils.getSDKStaticContentUrl().concat('assets/pzpega-logo-mark.svg');
 
     // this is a dummy "get", because right now images are in http and the main screen is https
     // so the images don't load automatically.  This call, makes an initial hit that allows the
@@ -100,8 +100,8 @@ export class NavbarComponent implements OnInit {
 
   initComponent() {
     this.ngZone.run(() => {
-      this.navIcon$ = this.PCore$.getAssetLoader().getStaticServerUrl().concat('assets/pzpega-logo-mark.svg');
-      this.navExpandCollapse$ = this.utils.getImageSrc('plus', this.PCore$.getAssetLoader().getStaticServerUrl());
+      this.navIcon$ = this.utils.getSDKStaticContentUrl().concat('assets/pzpega-logo-mark.svg');
+      this.navExpandCollapse$ = this.utils.getImageSrc('plus', this.utils.getSDKStaticContentUrl());
 
       // Then, continue on with other initialization
 
@@ -111,7 +111,7 @@ export class NavbarComponent implements OnInit {
       for (let page in this.navPages$) {
         this.navPages$[page]['iconName'] = this.utils.getImageSrc(
           this.navPages$[page]['pxPageViewIcon'],
-          this.PCore$.getAssetLoader().getStaticServerUrl()
+          this.utils.getSDKStaticContentUrl()
         );
       }
 
@@ -123,7 +123,7 @@ export class NavbarComponent implements OnInit {
 
       let oData = this.pConn$.getDataObject();
 
-      this.portalLogoImage$ = this.PCore$.getAssetLoader().getStaticServerUrl().concat('assets/pzpega-logo-mark.svg');
+      this.portalLogoImage$ = this.utils.getSDKStaticContentUrl().concat('assets/pzpega-logo-mark.svg');
       this.portalOperator$ = this.PCore$.getEnvironmentInfo().getOperatorName();
       this.portalOperatorInitials$ = this.utils.getInitials(this.portalOperator$);
 
@@ -139,10 +139,10 @@ export class NavbarComponent implements OnInit {
 
   navPanelCreateButtonClick() {
     if (this.navExpandCollapse$.indexOf('plus') > 0) {
-      this.navExpandCollapse$ = this.utils.getImageSrc('times', this.PCore$.getAssetLoader().getStaticServerUrl());
+      this.navExpandCollapse$ = this.utils.getImageSrc('times', this.utils.getSDKStaticContentUrl());
       this.bShowCaseTypes$ = true;
     } else {
-      this.navExpandCollapse$ = this.utils.getImageSrc('plus', this.PCore$.getAssetLoader().getStaticServerUrl());
+      this.navExpandCollapse$ = this.utils.getImageSrc('plus', this.utils.getSDKStaticContentUrl());
       this.bShowCaseTypes$ = false;
     }
 

--- a/src/app/_components/stages/stages.component.ts
+++ b/src/app/_components/stages/stages.component.ts
@@ -31,8 +31,8 @@ export class StagesComponent implements OnInit {
     // First thing in initialization is registering and subscribing to the AngularPConnect service
     this.angularPConnectData = this.angularPConnect.registerAndSubscribeComponent(this, this.onStateChange);
 
-    const imagePath = this.utils.getIconPath(this.PCore$.getAssetLoader().getStaticServerUrl());
-    this.checkSvgIcon$ = this.utils.getImageSrc('check', this.PCore$.getAssetLoader().getStaticServerUrl());
+    const imagePath = this.utils.getIconPath(this.utils.getSDKStaticContentUrl());
+    this.checkSvgIcon$ = this.utils.getImageSrc('check', this.utils.getSDKStaticContentUrl());
   }
 
   ngOnDestroy(): void {

--- a/src/app/_components/utility/utility.component.ts
+++ b/src/app/_components/utility/utility.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
+import { Utils } from '../../_helpers/utils';
 
 @Component({
   selector: 'app-utility',
@@ -16,7 +17,7 @@ export class UtilityComponent implements OnInit {
   headerIconUrl$: string;
   noItemsMessage$: string;
 
-  constructor() {}
+  constructor(private utils: Utils) {}
 
   ngOnInit(): void {
     if (!this.PCore$) {
@@ -26,7 +27,7 @@ export class UtilityComponent implements OnInit {
     this.configProps$ = this.pConn$.resolveConfigProps(this.pConn$.getConfigProps());
 
     this.headerIcon$ = this.configProps$['headerIcon'];
-    this.headerIconUrl$ = this.PCore$.getAssetLoader().getStaticServerUrl();
+    this.headerIconUrl$ = this.utils.getSDKStaticContentUrl();
     this.headerText$ = this.configProps$['headerText'];
     this.noItemsMessage$ = this.configProps$['noItemsMessage'];
   }

--- a/src/app/_helpers/utils.ts
+++ b/src/app/_helpers/utils.ts
@@ -4,6 +4,7 @@ import * as dayjs from 'dayjs';
 import * as customParseFormat from 'dayjs/plugin/customParseFormat';
 import * as localizedFormat from 'dayjs/plugin/localizedFormat';
 import * as relativeTime from 'dayjs/plugin/relativeTime';
+import { ServerConfigService } from '../_services/server-config.service';
 
 dayjs.extend(customParseFormat);
 dayjs.extend(localizedFormat);
@@ -15,7 +16,19 @@ export class Utils {
 
   viewContainerCount: number = 0;
 
-  constructor() {}
+  constructor(private scService: ServerConfigService) {}
+
+  getSDKStaticContentUrl() {
+    const sdkConfigServer = this.scService.getSdkConfigServer();
+
+    // NOTE: Needs a trailing slash! So add one if not provided
+    if (!sdkConfigServer.sdkContentServerUrl.endsWith('/')) {
+      sdkConfigServer.sdkContentServerUrl = `${sdkConfigServer.sdkContentServerUrl}/`;
+    }
+
+    return `${sdkConfigServer.sdkContentServerUrl}constellation/`;
+  }  
+
 
   consoleKidDump(pConn: any, level: number = 1, kidNum: number = 1) {
     let sDash = '';

--- a/src/app/_material_extensions/material-summary-item/material-summary-item.component.ts
+++ b/src/app/_material_extensions/material-summary-item/material-summary-item.component.ts
@@ -18,11 +18,11 @@ export class MaterialSummaryItemComponent implements OnInit {
   constructor(private utils: Utils) {}
 
   ngOnInit(): void {
-    this.imagePath$ = this.utils.getIconPath(this.PCore$.getAssetLoader().getStaticServerUrl());
+    this.imagePath$ = this.utils.getIconPath(this.utils.getSDKStaticContentUrl());
 
-    this.settingsSvgIcon$ = this.utils.getImageSrc('more', this.PCore$.getAssetLoader().getStaticServerUrl());
+    this.settingsSvgIcon$ = this.utils.getImageSrc('more', this.utils.getSDKStaticContentUrl());
     if (this.menuIconOverride$ != '') {
-      this.menuIconOverride$ = this.utils.getImageSrc(this.menuIconOverride$, this.PCore$.getAssetLoader().getStaticServerUrl());
+      this.menuIconOverride$ = this.utils.getImageSrc(this.menuIconOverride$, this.utils.getSDKStaticContentUrl());
     }
   }
 }


### PR DESCRIPTION
With latest update to 8.8.2 ConstellationJS files to get localization, etc. static content from Infinity static content server, now direct static content expected to be available in the SDK static content server to look there. Implement/use new method: Utils.getSDKStaticContentUrl()