### PR TITLE
mat icons are not loading in Storybooks issue fixed

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- <link rel="icon" type="image/x-icon" href="favicon.ico"> -->
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet" />
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
   </head>
   <body class="mat-typography">
     <app-root></app-root>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,5 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
 @import '@angular/material/prebuilt-themes/deeppurple-amber.css';
+@import 'https://fonts.googleapis.com/icon?family=Material+Icons';
 /*@import "@angular/material/prebuilt-themes/pink-bluegrey.css";*/
 
 html,


### PR DESCRIPTION
Issue: material icons are not rendering in Storybooks