### PR TITLE
Get Storybook assets into a directory and be ignored by Git and Prettier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,8 @@ test-results/
 playwright-report/
 
 .angular
+
+# storybook assets
+/storybook-assets
+/storybook-assetsgraph
+**/storybook-*.html

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@
 **/*.svg
 **/assets
 **/index.html
+**/storybook-*.html

--- a/angular.json
+++ b/angular.json
@@ -155,7 +155,7 @@
           "options": {
             "configDir": ".storybook",
             "browserTarget": "angularsdk:build",
-            "compodocArgs": ["-d", "."],
+            "compodocArgs": ["-d", "./storybook-assets"],
             "port": 6006
           }
         },


### PR DESCRIPTION
* Moved storybook assests into the `storybook-assets` directory.
* Git and Prettier should ignore these.