### PR TITLE
Added pcoreMocks to get SBs work with latest DXCB(this is backward compatible change)

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,9 @@
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { AngularPConnectService, getSdkComponentMap } from '@pega/angular-sdk-components';
 import { Preview, applicationConfig } from '@storybook/angular';
+import setPCoreMocks from '../__mocks__/pcoreMocks';
+
+setPCoreMocks();
 
 getSdkComponentMap();
 

--- a/__mocks__/pcoreMocks.ts
+++ b/__mocks__/pcoreMocks.ts
@@ -1,0 +1,27 @@
+export default function setPCoreMocks() {
+  if (!window.PCore) {
+    window.PCore = {} as any;
+  }
+
+  window.PCore.getEnvironmentInfo = () => {
+    return {
+      getUseLocale: () => 'en-GB',
+      getLocale: () => 'en-GB',
+      getTimeZone: () => ''
+    } as any;
+  };
+
+  window.PCore.getLocaleUtils = () => {
+    return {
+      getLocaleValue: (value: any) => value
+    } as any;
+  };
+
+  window.PCore.getConstants = (): any => {
+    return {
+      CASE_INFO: {
+        INSTRUCTIONS: ''
+      }
+    };
+  };
+}


### PR DESCRIPTION
* Added pcoreMocks to get SBs work with latest DXCB,.
* This isn't going to break the DXCB 24.2.11 i.e. backward compatible change.